### PR TITLE
enable limit of suggestions as a query parameter

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -17,7 +17,8 @@ def ping(request):
 def marking(request):
     text = request.body.decode('utf-8')
 
-    content = generate_markings(text)
+    max_suggestions = int(request.GET.get('limit', '-1'))
+    content = generate_markings(text, max_suggestions)
 
     return JsonResponse(content)
 


### PR DESCRIPTION
We currently hard-code the maximum number of suggestions per marking in the backend, this change allows the API user to dictate that.