### PR TITLE
limiting the number of suggestions when uploading a file

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -158,7 +158,8 @@ export class AppComponent {
             const file: File = fileList[0];
             const formData: FormData = new FormData();
             formData.append('uploadFile', file, file.name);
-            this.http.post(this.uploadDocumentURL, formData).subscribe(next => {
+            //I will jump out of a f*ing window
+            this.http.post(this.uploadDocumentURL + "?limit=5", formData).subscribe(next => {
                 this.processedText = next as ProcessedText;
             });
         } else {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -158,7 +158,6 @@ export class AppComponent {
             const file: File = fileList[0];
             const formData: FormData = new FormData();
             formData.append('uploadFile' + "?limit=5", file, file.name);
-            //I will jump out of a f*ing window
             this.http.post(this.uploadDocumentURL + "?limit=5", formData).subscribe(next => {
                 this.processedText = next as ProcessedText;
             });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -157,7 +157,7 @@ export class AppComponent {
         if (fileList.length === 1) {
             const file: File = fileList[0];
             const formData: FormData = new FormData();
-            formData.append('uploadFile' + "?limit=5", file, file.name);
+            formData.append('uploadFile', file, file.name);
             this.http.post(this.uploadDocumentURL + "?limit=5", formData).subscribe(next => {
                 this.processedText = next as ProcessedText;
             });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -157,7 +157,7 @@ export class AppComponent {
         if (fileList.length === 1) {
             const file: File = fileList[0];
             const formData: FormData = new FormData();
-            formData.append('uploadFile', file, file.name);
+            formData.append('uploadFile' + "?limit=5", file, file.name);
             //I will jump out of a f*ing window
             this.http.post(this.uploadDocumentURL + "?limit=5", formData).subscribe(next => {
                 this.processedText = next as ProcessedText;


### PR DESCRIPTION
When uploading files there were no limits on the suggestions words as shown in the image below
![Capture](https://user-images.githubusercontent.com/37506005/179318567-02cab39d-8818-401d-b137-df2cd6101d08.PNG)

These are the results after the fix 
![Capture2](https://user-images.githubusercontent.com/37506005/179318659-bc02ab9d-18e3-4003-96bc-1fb2caf4ff11.PNG)


