### PR TITLE
Fixed the Property 'toBeTruthy' does not exist on type 'Assertion' error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,9 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
-  }
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,8 +29,8 @@
     "strictInputAccessModifiers": true,
     "strictTemplates": true
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-
+  "exclude": [
+    "./cypress.config.ts",
+    "cypress"
+]
 }


### PR DESCRIPTION
Fixed the Property 'toBeTruthy' does not exist on type 'Assertion' error that came from by using Cypress and Jest in the same project.