### PR TITLE
Collapse expand arrows

### DIFF
--- a/cypress/e2e/general-flow.cy.js
+++ b/cypress/e2e/general-flow.cy.js
@@ -8,20 +8,43 @@ describe("a general flow of quill", () => {
     });
 
     it("will mark typos in the editor", () => {
-        cy.get("#editor > p > .typo").should("not.exist");
+        cy.get('[data-test="editor"] > p > .typo').should("not.exist");
         cy.get('[data-test="editor"]').type("gabmim ");
-        cy.get("#editor > p > .typo").should("exist");
+        cy.get('[data-test="editor"] > p > .typo').should("exist");
     });
 
     it("will mark loanwords in the editor", () => {
         cy.get('[data-test="editor"] > p > .loanword').should("not.exist");
         cy.get('[data-test="editor"]').type("lider ");
-        cy.get("#editor > p > .loanword").should("exist");
+        cy.get('[data-test="editor"] > p > .loanword').should("exist");
     });
 
     it("will test if  Opening and closing the offcanvas works as expected.", () => {
         cy.get('[data-test="navbar-toggler-icon"]').click();
         cy.get(".offcanvas.offcanvas-start.show").should("exist");
         cy.get('[data-test="close-offcanvas-button"]').click();
+    });
+
+    it("will click on the expand/collapse arrows and then choose on a suggestion", () => {
+        cy.get('[data-test="editor"]').type("eshte");
+        cy.get('[data-test="suggestion"]').children().should("have.length", 4);
+        cy.get(
+            '[data-test="oscillate-suggestions-button"].bi-arrow-right-square'
+        ).click();
+        cy.get('[data-test="suggestion"]')
+            .children()
+            .should("have.length.gt", 4);
+        cy.get(
+            '[data-test="oscillate-suggestions-button"].bi-arrow-left-square'
+        ).click();
+        cy.get('[data-test="suggestion"]').children().should("have.length", 4);
+        cy.get(
+            '[data-test="oscillate-suggestions-button"].bi-arrow-right-square'
+        ).click();
+        cy.get('[data-test="suggestion"]')
+            .children()
+            .should("have.length.gt", 4);
+        cy.get('[data-test="suggestion"]').contains("është").click();
+        cy.get('[data-test="editor"]').should("have.text", "është");
     });
 });

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+    "hosting": {
+        "public": "dist/quill",
+        "ignore": [
+            "firebase.json",
+            "**/.*",
+            "**/node_modules/**"
+        ],
+        "rewrites": [
+            {
+                "source": "**",
+                "destination": "/index.html"
+            }
+        ]
+    }
+}

--- a/mock-server/data/generateMarkingsForParagraphs.json
+++ b/mock-server/data/generateMarkingsForParagraphs.json
@@ -733,6 +733,204 @@
         }
     },
     {
+        "request": "<p>eshte</p>",
+        "response": {
+            "text": "<p>eshte</p>",
+            "textMarkings": [
+                {
+                    "from": 0,
+                    "to": 5,
+                    "type": "typo",
+                    "subtype": "gabim gramatikor, drejtshkrim",
+                    "description": "kjo fjal\u00eb nuk ekziston, a doje t\u00eb shkruaje",
+                    "suggestions": [
+                        {
+                            "display": "shute",
+                            "action": "shute"
+                        },
+                        {
+                            "display": "shtie",
+                            "action": "shtie"
+                        },
+                        {
+                            "display": "esht\u00eb",
+                            "action": "esht\u00eb"
+                        },
+                        {
+                            "display": "behte",
+                            "action": "behte"
+                        },
+                        {
+                            "display": "shite",
+                            "action": "shite"
+                        },
+                        {
+                            "display": "peshe",
+                            "action": "peshe"
+                        },
+                        {
+                            "display": "teste",
+                            "action": "teste"
+                        },
+                        {
+                            "display": "oshte",
+                            "action": "oshte"
+                        },
+                        {
+                            "display": "epshe",
+                            "action": "epshe"
+                        },
+                        {
+                            "display": "hesht",
+                            "action": "hesht"
+                        },
+                        {
+                            "display": "lehte",
+                            "action": "lehte"
+                        },
+                        {
+                            "display": "shter",
+                            "action": "shter"
+                        },
+                        {
+                            "display": "vesht",
+                            "action": "vesht"
+                        },
+                        {
+                            "display": "shteg",
+                            "action": "shteg"
+                        },
+                        {
+                            "display": "shote",
+                            "action": "shote"
+                        },
+                        {
+                            "display": "reshe",
+                            "action": "reshe"
+                        },
+                        {
+                            "display": "resht",
+                            "action": "resht"
+                        },
+                        {
+                            "display": "shtet",
+                            "action": "shtet"
+                        },
+                        {
+                            "display": "ehte",
+                            "action": "ehte"
+                        },
+                        {
+                            "display": "shete",
+                            "action": "shete"
+                        },
+                        {
+                            "display": "beshte",
+                            "action": "beshte"
+                        },
+                        {
+                            "display": "veshe",
+                            "action": "veshe"
+                        },
+                        {
+                            "display": "desht",
+                            "action": "desht"
+                        },
+                        {
+                            "display": "qeshte",
+                            "action": "qeshte"
+                        },
+                        {
+                            "display": "vehte",
+                            "action": "vehte"
+                        },
+                        {
+                            "display": "meste",
+                            "action": "meste"
+                        },
+                        {
+                            "display": "ethte",
+                            "action": "ethte"
+                        },
+                        {
+                            "display": "heshte",
+                            "action": "heshte"
+                        },
+                        {
+                            "display": "yshte",
+                            "action": "yshte"
+                        },
+                        {
+                            "display": "eshtek",
+                            "action": "eshtek"
+                        },
+                        {
+                            "display": "ishte",
+                            "action": "ishte"
+                        },
+                        {
+                            "display": "seshe",
+                            "action": "seshe"
+                        },
+                        {
+                            "display": "dehte",
+                            "action": "dehte"
+                        },
+                        {
+                            "display": "eshke",
+                            "action": "eshke"
+                        },
+                        {
+                            "display": "qeste",
+                            "action": "qeste"
+                        },
+                        {
+                            "display": "veste",
+                            "action": "veste"
+                        },
+                        {
+                            "display": "deshe",
+                            "action": "deshe"
+                        },
+                        {
+                            "display": "estet",
+                            "action": "estet"
+                        },
+                        {
+                            "display": "reshte",
+                            "action": "reshte"
+                        },
+                        {
+                            "display": "shtek",
+                            "action": "shtek"
+                        },
+                        {
+                            "display": "feste",
+                            "action": "feste"
+                        },
+                        {
+                            "display": "\u00ebsht\u00eb",
+                            "action": "\u00ebsht\u00eb"
+                        },
+                        {
+                            "display": "leshe",
+                            "action": "leshe"
+                        },
+                        {
+                            "display": "qeshe",
+                            "action": "qeshe"
+                        },
+                        {
+                            "display": "veshte",
+                            "action": "veshte"
+                        }
+                    ],
+                    "paragraph": 0
+                }
+            ]
+        }
+    },
+    {
         "request": "<p>saktë saktë</p>",
         "response": {
             "text": "<p>sakt\u00eb sakt\u00eb</p>",

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -389,6 +389,7 @@
                                         line-height: inherit;
                                         cursor: pointer;
                                     "
+                                    data-test="oscillate-suggestions-button"
                                 ></h3>
                             </div>
                         </div>


### PR DESCRIPTION
Addressing https://github.com/OpenCovenant/quill/issues/130. Can you test this locally on Electron as well as Chrome? 
Additionally feel free to add another test case that covers clicking on the expand/collapse buttons on multiple markings at the same time.