### PR TITLE
fixed the off canvas menu added dark mode, and the hamburger icon

### DIFF
--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -138,7 +138,7 @@ hr {
 }
 
 .dark-mode-input:checked ~ .slider {
-    background-color: #9a9a9a;;
+    background-color: #797979;;
 }
 
 .slider::before {
@@ -156,8 +156,8 @@ hr {
 
 .dark-mode-input:checked ~ .slider::before {
     transform: translateX(1.5rem);
-    background-color: #9a9a9a;
-    box-shadow: inset -7px -3px 0 0 var(--light);
+    background-color: #797979;
+    box-shadow: inset -7px -3px 0 0 #ffffff;;
 }
 
 .settings-gear-dark-mode {

--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -32,6 +32,10 @@
     width: 1.4rem;
 }
 
+.navbar-toggler-icon-dark-mode{
+    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") center/1em auto no-repeat;
+}
+
 .off-canvas-start-button {
     border: 0;
     background-color: #f9f9f9;
@@ -42,8 +46,22 @@
     background-color: #e3e3e3;
 }
 
+.offcanvas-header-dark-mode{
+    background-color: var(--dark-mode-theme);
+    color: var(--light);
+}
+
+.offcanvas-body-dark-mode{
+    background-color: var(--dark-mode-theme);
+    color: var(--light);
+}
+
+.offcanvas-navText-dark-mode{
+    color: var(--light) !important;
+}
+
 hr {
-    background-color: #353434;
+    background-color: #9a9a9a;
     height: 1px;
     border: none;
     margin-bottom: 0;
@@ -65,7 +83,7 @@ hr {
 }
 
 .navText:hover {
-    background-color: rgba(241, 238, 238, 0.952);
+    background-color: #595959;
     color: black;
 }
 
@@ -74,9 +92,17 @@ hr {
     color: #3a3a3a;
 }
 
+.offcanvas-bi-info-circle-dark-mode{
+    color: var(--light);
+}
+
 .offcanvas-start {
     border-radius: 0 3px 3px 0;
     width: 350px;
+}
+
+.offcanvas-start-dark-mode{
+    background-color: var(--dark-mode-theme);
 }
 
 .offcanvas-body {
@@ -112,7 +138,7 @@ hr {
 }
 
 .dark-mode-input:checked ~ .slider {
-    background-color: var(--dark);
+    background-color: #9a9a9a;;
 }
 
 .slider::before {
@@ -130,7 +156,7 @@ hr {
 
 .dark-mode-input:checked ~ .slider::before {
     transform: translateX(1.5rem);
-    background-color: var(--dark);
+    background-color: #9a9a9a;
     box-shadow: inset -7px -3px 0 0 var(--light);
 }
 
@@ -143,4 +169,8 @@ hr {
     padding-top: 2rem;
     padding-left: 1rem;
     padding-right: 1rem;
+}
+
+.offcanvas-close-button-dark-mode{
+    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3e%3cpath d='M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z'/%3e%3c/svg%3e") center/1em auto no-repeat;
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -16,6 +16,9 @@
             >
                 <span
                     class="navbar-toggler-icon"
+                    [ngClass]="{
+                        'navbar-toggler-icon-dark-mode': darkModeService.isDarkMode
+                    }"
                     data-test="navbar-toggler-icon"
                 ></span>
             </button>
@@ -46,23 +49,35 @@
 <div
     id="offcanvasStart"
     class="offcanvas offcanvas-start"
+    [ngClass]="{
+        'offcanvas-start-dark-mode': darkModeService.isDarkMode
+    }"
     tabindex="-1"
     aria-labelledby="offcanvasStartLabel"
->
-    <div class="offcanvas-header">
+    >
+    <div class="offcanvas-header"
+    [ngClass]="{
+        'offcanvas-header-dark-mode': darkModeService.isDarkMode
+    }">
         <h5 id="offcanvasStartLabel">penda</h5>
         <button
             id="offcanvasCloseButton"
             type="button"
             class="btn-close text-reset"
+            [ngClass]="{
+                'offcanvas-close-button-dark-mode': darkModeService.isDarkMode
+            }"
             data-bs-dismiss="offcanvas"
             aria-label="Close"
             data-test="close-offcanvas-button"
         ></button>
     </div>
-    <hr />
+    <hr/>
     <br />
-    <div class="offcanvas-body">
+    <div class="offcanvas-body"
+    [ngClass]="{
+        'offcanvas-body-dark-mode': darkModeService.isDarkMode
+    }">
         <div class="list-group list-group-flush">
             <div>
                 <!--                <div style="box-shadow: 0 0 1px 1px #E3E3E3AE;">-->
@@ -83,11 +98,18 @@
                         data-test="settings-button"
                         routerLink="/settings"
                         class="navText list-group-item-action mb-3"
+                        [ngClass]="{
+                            'offcanvas-navText-dark-mode': darkModeService.isDarkMode
+                        }"
                         role="button"
                         data-bs-toggle="offcanvas"
                         data-bs-target="#offcanvasStart"
                         aria-controls="offcanvasStart"
-                        ><i class="bi bi-gear"></i>Cilësimet</a
+                        ><i class="bi bi-gear"
+                        [ngClass]="{
+                            'offcanvas-bi-info-circle-dark-mode': darkModeService.isDarkMode
+                        }">
+                    </i>Cilësimet</a
                     >
                 </div>
                 <div>
@@ -95,9 +117,16 @@
                         href="https://github.com/OpenCovenant"
                         role="button"
                         class="navText list-group-item-action mb-3"
+                        [ngClass]="{
+                            'offcanvas-navText-dark-mode': darkModeService.isDarkMode
+                        }"
                         target="_blank"
                         rel="noopener noreferrer"
-                        ><i class="bi bi-house-door"></i>Rreth&nbsp;Nesh</a
+                        ><i class="bi bi-house-door"
+                        [ngClass]="{
+                            'offcanvas-bi-info-circle-dark-mode': darkModeService.isDarkMode
+                        }">
+                        </i>Rreth&nbsp;Nesh</a
                     >
                 </div>
                 <div>
@@ -105,14 +134,21 @@
                         href="https://github.com/OpenCovenant/quill"
                         role="button"
                         class="navText list-group-item-action mb-3"
+                        [ngClass]="{
+                            'offcanvas-navText-dark-mode': darkModeService.isDarkMode
+                        }"
                         target="_blank"
                         rel="noopener noreferrer"
-                        ><i class="bi bi-info-circle"></i>Rreth&nbsp;Penda</a
+                        ><i class="bi bi-info-circle"
+                        [ngClass]="{
+                            'offcanvas-bi-info-circle-dark-mode': darkModeService.isDarkMode
+                        }">
+                    </i>Rreth&nbsp;Penda</a
                     >
                 </div>
                 <br />
             </div>
-            <hr />
+            <hr/>
             <div class="d-flex dark-mode-div">
                 <div>Modalitet i Errët</div>
                 <div class="toggle-switch">


### PR DESCRIPTION
I successfully implemented the off-canvas menu to function in dark mode, and the hamburger menu ; here is the previous version.
![Screenshot from 2023-09-16 23-42-48](https://github.com/OpenCovenant/quill/assets/37506005/ec8b7c2c-cbfd-40ac-a9de-1a3fccdfc854)
![Screenshot from 2023-09-16 23-42-55](https://github.com/OpenCovenant/quill/assets/37506005/f97f5a41-33ee-435c-a58a-0d247eac2ce1)
And here is the updated version.
![Screenshot from 2023-09-16 23-36-41](https://github.com/OpenCovenant/quill/assets/37506005/2e937212-c731-4468-82ea-30afadb36200)
![Screenshot from 2023-09-16 23-36-49](https://github.com/OpenCovenant/quill/assets/37506005/d20677b7-c46d-4a3e-87cf-b9fd5bfe0e41)
I've implemented the following modifications:

- Adjusted the hover color of the navigation text to #595959.
- Changed the text color to white.
- I also changed the X button color to white 
- Set the hamburger menu icon to white in dark mode.
- Enhanced the visibility of the dark mode button background.