### PR TITLE
Back arrow settings

### DIFF
--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -86,7 +86,7 @@
     border-radius: 50%;
 }
 
-.bi-arrow-left:before{
+.bi-arrow-left:before {
     padding-bottom: 1.3rem;
     font-size: 1.4rem;
     cursor: pointer;

--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -1,3 +1,10 @@
+.main-settings-div {
+    display: flex;
+    justify-content: center;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+}
+
 .marking-type-label {
     position: relative;
     display: inline-block;
@@ -77,4 +84,10 @@
 
 .slider.round:before {
     border-radius: 50%;
+}
+
+.bi-arrow-left:before{
+    padding-bottom: 1.3rem;
+    font-size: 1.4rem;
+    cursor: pointer;
 }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -1,4 +1,4 @@
-<div style="display: flex; justify-content: center; padding-top: 2rem">
+<div class="main-settings-div">
     <div class="card p-3" style="width: 60%"
          [ngClass]="{
                     'settings-dark-mode': darkModeService.isDarkMode
@@ -7,6 +7,12 @@
              [ngClass]="{
                     'card-body-dark-mode': darkModeService.isDarkMode
                 }">
+            <span
+                routerLink="/"
+                class="settings-home-button"
+                data-test="settings-home-button">
+                <i class="bi bi-arrow-left"></i>
+            </span>
             <h5 class="card-title">Cilësimet</h5>
             <p class="card-text">
                 Shto ose hiq lloje shenjimesh për të cilat dëshironi të shikoni


### PR DESCRIPTION
**Displayed below is an image of the settings page without the back button.**

![Screenshot from 2023-09-19 00-11-04](https://github.com/OpenCovenant/quill/assets/37506005/cc899687-c80b-48ac-8a9a-2b353aa87318)

**Below, here is an image of the settings page with the back arrow button.**

![Screenshot from 2023-09-19 00-10-55](https://github.com/OpenCovenant/quill/assets/37506005/e6225dd7-9af8-449d-ab7a-832062973594)

Here is a summary of what happened in this pull request.

- Increased the bottom padding to create more space between the content and the footer due to it being too close.
- Implemented a back button that now redirects users to the home page.
- Addressed and corrected some issues with inline CSS.
