### PR TITLE
AI markings indicator

### DIFF
--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -474,6 +474,11 @@
     color: var(--dark-mode-anti-theme);
 }
 
+.bi-stars {
+    padding-right: 7px;
+    color: purple;
+}
+
 /*TODO change color on .suggestion:hover ?*/
 @media (max-width: 800px) {
     .high-level-container {

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -249,7 +249,7 @@
                             'list-group-item-dark-mode':
                                 darkModeService.isDarkMode
                         }"
-                    >
+                    ><i class="bi bi-stars"></i>
                         <b>sipas rregullave gramatikore</b> -
                         <span>shenjime për gabime gramatikore të llojeve të ndryshme</span>
                     </li>
@@ -310,7 +310,8 @@
                             }"
                         >
                             <div class="information-circle-flex">
-                                <div>
+                                <div *ngIf="textMarking.subtype === 'gabim gramatikor'">
+                                    <i class="bi bi-stars"></i>
                                     <b>{{ textMarking.subtype }}</b> -
                                     <span>{{ textMarking.description }}</span>
                                 </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -310,8 +310,9 @@
                             }"
                         >
                             <div class="information-circle-flex">
-                                <div *ngIf="textMarking.subtype === 'gabim gramatikor'">
-                                    <i class="bi bi-stars"></i>
+                                <div>
+                                    <i *ngIf="textMarking.subtype === 'grammatical'"
+                                       class="bi bi-stars"></i>
                                     <b>{{ textMarking.subtype }}</b> -
                                     <span>{{ textMarking.description }}</span>
                                 </div>
@@ -419,6 +420,8 @@
                         >
                             <div class="information-circle-flex">
                                 <div>
+                                    <i *ngIf="processedText?.textMarkings?.[highlightedMarkingIndex]?.subtype === 'grammatical'"
+                                       class="bi bi-stars"></i>
                                     <b
                                         >{{  processedText?.textMarkings?.[highlightedMarkingIndex]?.subtype }}</b
                                     >


### PR DESCRIPTION
In the provided screenshots, you can observe the AI marking indicator. At line 313, within the code snippet, the condition `<div *ngIf="textMarking.subtype === 'gabim gramatikor'">` should be modified to align with the specific subtype associated with the AI.
The provided example has been tested with <div *ngIf="textMarking.subtype === 'gabim gramatikor, drejtshkrim'">.
![Screenshot from 2023-10-29 18-57-06](https://github.com/OpenCovenant/quill/assets/37506005/9ac56444-255f-41e2-b87e-231e51370072)
![Screenshot from 2023-10-29 18-57-12](https://github.com/OpenCovenant/quill/assets/37506005/0fedae3e-1935-4abc-b618-22f2a7872021)