### PR TITLE
Late template issue when all suggestions are applied

### DIFF
--- a/mock-server/data/generateMarkingsForParagraphs.json
+++ b/mock-server/data/generateMarkingsForParagraphs.json
@@ -2554,6 +2554,13 @@
         }
     },
     {
+        "request": "<p>gabimi gabime</p>",
+        "response": {
+            "text": "<p>gabimi gabime</p>",
+            "textMarkings": []
+        }
+    },
+    {
         "request": "<p>pra gabmim kaq</p>",
         "response": {
             "text": "<p>pra gabmim kaq</p>",

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -63,6 +63,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
     }[] = [];
     deleteTimer: number | undefined;
     characterCountPrePost: number = 0;
+    cardCountSelectedPrePost: number = 0;
     cardsElementToRemove: any[] = [];
     animationRemoved = new EventEmitter<void>();
     suggestedMarkingCardCounter: number = 0;
@@ -229,8 +230,9 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
      * @param {number} suggestionIndex the index of the chosen Suggestion of the above TextMarking
      */
     chooseSuggestion(textMarkingIndex: number, suggestionIndex: number): void {
-        if (this.cardsToRemove.length >= 1) return; // prevents collision action between suggestion and deletion
+        // if (this.cardsToRemove.length >= 1) return; // prevents collision action between suggestion and deletion
         this.suggestedMarkingCardCounter++;
+        this.cardCountSelectedPrePost++;
         this.cardSuggestionsToRemove.push({
             textMarkingIndex,
             suggestionIndex
@@ -321,10 +323,9 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
         removeItem: number,
         lastIndex: number
     ): void {
-        if (lastIndex === 0) {
-            setTimeout(() => {
-                this.triggerSuggestionEmitterAnimation(lastIndex === index);
-            }, 100);
+        if (this.cardCountSelectedPrePost >= document.querySelectorAll('.sticky .card').length) {
+            const editor: HTMLElement = document.getElementById(this.EDITOR_KEY)!;
+            this.processTextMarkingSelected(editor)
             return;
         }
 
@@ -450,6 +451,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
                 this.cardSuggestionsToRemove = [];
                 this.characterCountPrePost = 0;
                 this.suggestedMarkingCardCounter = 0;
+                this.cardCountSelectedPrePost = 0;
             });
     }
 
@@ -593,8 +595,9 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
      */
     deleteTextMarking(textMarkingIndex: number): void {
         // based on the assumption that all spans within the paragraphs of the editor are markings
-        if (this.cardSuggestionsToRemove.length >= 1) return; // prevents collision action between suggestion and deletion
+        // if (this.cardSuggestionsToRemove.length >= 1) return; // prevents collision action between suggestion and deletion
 
+        this.cardCountSelectedPrePost++;
         this.cardsToRemove.push(textMarkingIndex);
         this.slideFadeAnimationCard(textMarkingIndex);
 
@@ -773,6 +776,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
         this.suggestedMarkingCardCounter = 0;
         this.textMarkingParagraphIndex = [];
         this.characterCountPrePost = 0;
+        this.cardCountSelectedPrePost = 0;
     }
 
     /**


### PR DESCRIPTION
## Late Template issue #369
Fixes the issue of overly late template markings appearance after all suggestions are selected. This is a special case meaning it only works when all suggestions are selected. This does not fix the issue when both suggestions and removal are selected simultaneously. All Cypress test are good to go.

##video
 

https://github.com/OpenCovenant/quill/assets/57508905/fba6e77d-c665-4b37-b0d3-dc5ebf49e8fe

