### PR TITLE
remove wait and some comments in move-up-card-markings-animation.cy.js

### DIFF
--- a/cypress/e2e/move-up-card-markings-animation.cy.js
+++ b/cypress/e2e/move-up-card-markings-animation.cy.js
@@ -4,29 +4,16 @@ describe("Move up markings cards animation", () => {
     });
 
     it("Will delete one card and trigger the move up animation for the remaining cards", () => {
-        // Check initial state
         cy.get(".typo").should("not.exist");
-
-        // Add some text
         cy.get('[data-test="editor"]').type("sakt eshte");
-
-        // Wait for the button to appear
         cy.get('[data-test="suggestion"]').should("be.visible");
 
         cy.get('[data-test="marking-card"]').first()
             .find('[data-test="suggestion"]').first()
             .click();
 
-        //Check if card has the fade-out class
         cy.get('[data-test="marking-card"]').first().should("have.class", "fade-out");
-
-        //wait for the animation to complete
-        cy.wait(500);
-
-        // Checks if other cards have triggered the move-up-animation
         cy.get('[data-test="marking-card"]').first().should("have.class", "move-up-animation");
-
-        // Checks if other cards still exist
         cy.get('[data-test="marking-card"]').should("have.length", 2);
     });
 });


### PR DESCRIPTION
Created a small PR @vaqueraoscar0.
Removed the `cy.wait` because `cy.get` already waits for some time by default (see https://docs.cypress.io/api/commands/get#Arguments and https://docs.cypress.io/guides/references/configuration#Timeouts). Let me know if you still think we should keep this.

Also removed some comments because the written code is already quite clear.