### PR TITLE
Reduced the height of side-menu-button

### DIFF
--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -1,6 +1,8 @@
 .header-name-gear-icon {
     margin-left: 3rem;
     font-size: 1.4rem;
+    display: flex;
+    align-items: center;
 }
 
 .penda-header-logo {
@@ -49,9 +51,13 @@
      letter-spacing: 0.005rem;
 }
 
+/* compress side menu button (only) vertically #411 */
 .off-canvas-start-button {
     border: 0;
     border-radius: 0.5rem;
+    height: 30px;
+    display: flex;
+    align-items: center;
 }
 
 .off-canvas-start-button:hover {


### PR DESCRIPTION
- Added the height of **side-menu-button** to `30px` inside `.off-canvas-start-button` and centered the burger-icon inside it using flex.
- Added `display: flex` to center the elements inside `.header-name-gear-icon`.

Let me know if you need any customization. I also suggest that the **penda text** `font-size` should have been increased instead of reducing the height of **side-menu-button**.